### PR TITLE
VARNS-6: Fixes missing Participants bug discovered after feature was merged

### DIFF
--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/dialogs/simulation/SimulationWizard.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/dialogs/simulation/SimulationWizard.java
@@ -27,6 +27,9 @@ public class SimulationWizard extends Wizard<Simulation> {
     }
 
     protected List<WizardPage> build() {
+        this.roles.getData().add(new ScrumRole("Developer"));
+        this.roles.getData().add(new ScrumRole("Scrum Master"));
+        this.roles.getData().add(new ScrumRole("Product Owner"));
         return List.of(
                 new GeneralPage(simulationName, sprintCount),
                 new ParticipantsPage(users, roles));


### PR DESCRIPTION
@nqsullivan  found a bug where the Partipants Page was no longer being populated due to the Roles Page being deleted. I hard coded 3 roles to resolve this issue.