### PR TITLE
[VARNS-101] Clicking start simulation button without creating a new simulation or setting the simulation context breaks the simulation

### DIFF
--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/DemoPane.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/DemoPane.java
@@ -2,6 +2,7 @@ package com.groupesan.project.java.scrumsimulator.mainpackage.ui.panels;
 
 import com.groupesan.project.java.scrumsimulator.mainpackage.core.*;
 import com.groupesan.project.java.scrumsimulator.mainpackage.state.SimulationSingleton;
+import com.groupesan.project.java.scrumsimulator.mainpackage.state.SimulationStateManager;
 import com.groupesan.project.java.scrumsimulator.mainpackage.ui.widgets.BaseComponent;
 
 import javax.swing.*;
@@ -78,7 +79,7 @@ public class DemoPane extends JFrame implements BaseComponent {
 
         startSimulationButton = new JButton("Start Simulation");
         startSimulationButton.addActionListener(
-                e -> handleButtonAction(new SimulationPane(this)));
+                e -> onStartSimulationClick());
 
         potentialBlockersButton = new JButton("Potential Blockers");
         potentialBlockersButton.addActionListener(
@@ -183,7 +184,7 @@ public class DemoPane extends JFrame implements BaseComponent {
         switch (role) {
             case SCRUM_MASTER:
                 panel.add(createButton("Simulation Configuration", () -> handleButtonAction(new SimulationConfigurationPane(this))));
-                panel.add(createButton("Start Simulation", () -> handleButtonAction(new SimulationPane(this))));
+                panel.add(createButton("Start Simulation", this::onStartSimulationClick));
                 break;
             case DEVELOPER:
                 break;
@@ -191,7 +192,7 @@ public class DemoPane extends JFrame implements BaseComponent {
                 break;
             case SCRUM_ADMIN:
                 panel.add(createButton("Simulation Configuration", () -> handleButtonAction(new SimulationConfigurationPane(this))));
-                panel.add(createButton("Start Simulation", () -> handleButtonAction(new SimulationPane(this))));
+                panel.add(createButton("Start Simulation", this::onStartSimulationClick));
                 // TODO: Add Show Simulation History Button here
                 break;
         }
@@ -251,5 +252,13 @@ public class DemoPane extends JFrame implements BaseComponent {
         updateStoryStatusButton.setEnabled(enabled);
         simulationButton.setEnabled(enabled);
         sprintBacklogsButton.setEnabled(enabled);
+    }
+
+    private void onStartSimulationClick() {
+        if (SimulationStateManager.getInstance().getCurrentSimulation() == null) {
+            JOptionPane.showMessageDialog(this,"Please Select a Simulation Configuration before starting");
+        } else {
+            handleButtonAction(new SimulationPane(this));
+        }
     }
 }

--- a/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/SimulationPane.java
+++ b/src/main/java/com/groupesan/project/java/scrumsimulator/mainpackage/ui/panels/SimulationPane.java
@@ -7,7 +7,6 @@ import javax.swing.JOptionPane;
 
 import java.awt.FlowLayout;
 import java.awt.BorderLayout;
-import java.awt.Dimension;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -24,9 +23,9 @@ import com.groupesan.project.java.scrumsimulator.mainpackage.ui.widgets.BaseComp
 
 public class SimulationPane extends JFrame implements SimulationListener, BaseComponent {
 
-    private SimulationProgressPane progressPane;
-    private JFrame parent;
-    private SimulationStateManager simulationStateManager;
+    private final SimulationProgressPane progressPane;
+    private final JFrame parent;
+    private final SimulationStateManager simulationStateManager;
 
     public SimulationPane(JFrame parent) {
         this.parent = parent;


### PR DESCRIPTION
https://tree.taiga.io/project/ser515asu-ser515-VARNS/issue/101

- [X] Fixing this bug should add a check that blocks the user from starting a simulation if one isn't configured in the current context.

- [X] It should not lock up the whole UI.